### PR TITLE
Rename python-pathlib2 to pathlib2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "2.1.0" %}
 
 package:
-  name: python-pathlib2
+  name: pathlib2
   version: {{ version }}
 
 source:


### PR DESCRIPTION
@pelson this is another one that is bring a lot of grieve to users. I remove the binaries from the channel and sent https://github.com/conda-forge/pickleshare-feedstock/pull/3 too.